### PR TITLE
Fix CMake module base filename

### DIFF
--- a/src/example/CMakeLists.txt
+++ b/src/example/CMakeLists.txt
@@ -32,6 +32,7 @@ install(TARGETS example
     NAMELINK_COMPONENT libexample-dev
 )
 install(EXPORT example
+  FILE example-config.cmake
   DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/example"
   COMPONENT libexample-dev
   NAMESPACE example::


### PR DESCRIPTION
This patch renames `example.cmake` to `example-config.cmake`. This fixes a bug in which `find_package(example)` fails to locate the CMake module shipped by this project.

See the upstream CMake documentation for `find_package` for details about which file basenames are accepted when searching for a CMake modules via `find_package`, but names like `example.cmake` are not on the search path and will not be discovered properly.

Using `example-config.cmake` resolves this issue.